### PR TITLE
Fix for bug #1

### DIFF
--- a/qubic/io/_io.py
+++ b/qubic/io/_io.py
@@ -61,7 +61,7 @@ def read_map(filename, field=None, dtype=float, nest=False, partial=False):
             field = range(header['TFIELDS'])
         out = hp.read_map(filename, dtype=dtype, nest=nest, field=field,
                           h=True, verbose=False)
-        out, header = out[:-1], out[-1]
+        out, header = out[:-1], fits.header.Header(out[-1])
         out = np.column_stack(out)
         out = out.view(ndarraywrap)
         out.header = header


### PR DESCRIPTION
The object returned by `read_map` now uses `astropy.io.header.Header` to
inizialize the header, even when reading maps using Healpy.